### PR TITLE
Update PyPI license classifier.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,9 @@ setup_args = dict(
     packages=[NAME],
     package_data=extract_package_data(),
     classifiers=[
-        'License :: OSI Approved :: Open Government License',
+        # For full license details, see
+        # http://reference.data.gov.uk/id/open-government-licence
+        'License :: Freely Distributable',
         'Development Status :: 1 - Planning Development Status',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',


### PR DESCRIPTION
This PR addresses the [comment](https://github.com/SciTools/iris-sample-data/pull/14#discussion_r66327978) raised by @QuLogic regarding the PyPI license classifier.

Ideally, we should be specifying an OGL but that isn't available under the [PyPI trove classifiers](https://pypi.python.org/pypi?%3Aaction=list_classifiers).

On advise from *Intellectual Property Rights* our closest/best option is `License :: Freely Distributable`.

I've added a comment to the `setup.py` for clarification, and the `README.rst` already contains a link to the actual [Open Government Licence](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/) ... so I believe this is a better fit for what we want/should have.