### PR TITLE
Remove unnecessary _get_path function.

### DIFF
--- a/iris_sample_data/__init__.py
+++ b/iris_sample_data/__init__.py
@@ -3,10 +3,8 @@
 import os
 
 
-def _get_path():
-    return os.path.join(os.path.abspath(os.path.dirname(__file__)), 'sample_data')
-
-
+# Iris sample data version.
 __version__ = '1.0.0-dev'
 
-path = _get_path()
+# Root directory containing the iris sample data.
+path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'sample_data')


### PR DESCRIPTION
Tidy away unnecessary private module function `iris_sample_data._get_path`.