### PR TITLE
Bump to release version v1.2.0.

### DIFF
--- a/iris_sample_data/__init__.py
+++ b/iris_sample_data/__init__.py
@@ -4,7 +4,7 @@ import os
 
 
 # Iris sample data version.
-__version__ = '1.0.0-dev'
+__version__ = '2.0.0'
 
 # Root directory containing the iris sample data.
 path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'sample_data')


### PR DESCRIPTION
There's a bit of history that I never realised i.e. that we previously tagged at `v1.0` and `v1.1` [releases](https://github.com/SciTools/iris-sample-data/releases).

So the first importable `iris_sample_data` will be packaged at version `v2.0`